### PR TITLE
Update and re-export cargo_metadata

### DIFF
--- a/auditable-build/Cargo.toml
+++ b/auditable-build/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2018"
 auditable-serde = {path = "../auditable-serde", features = ["from_metadata"]}
 miniz_oxide = {version = "0.4.0"}
 serde_json = {version =  "1.0.57"}
-cargo_metadata = "0.11"
+cargo_metadata = "0.15.0"

--- a/auditable-serde/Cargo.toml
+++ b/auditable-serde/Cargo.toml
@@ -19,8 +19,8 @@ toml = ["cargo-lock"]
 [dependencies]
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1.0.57"
-semver = { version = "0.10", features = ["serde"] }
-cargo_metadata = { version = "0.11", optional = true }
+semver = { version = "1.0", features = ["serde"] }
+cargo_metadata = { version = "0.15", optional = true }
 cargo-lock = { version = "4.0.1", default-features = false, optional = true }
 
 [[example]]

--- a/auditable-serde/src/lib.rs
+++ b/auditable-serde/src/lib.rs
@@ -50,7 +50,7 @@ use std::convert::TryInto;
 #[cfg(any(feature = "from_metadata",feature = "toml"))]
 use std::convert::TryFrom;
 #[cfg(feature = "from_metadata")]
-use cargo_metadata;
+pub use cargo_metadata;
 #[cfg(feature = "from_metadata")]
 use std::{error::Error, cmp::Ordering::*, cmp::min, fmt::Display, collections::HashMap};
 


### PR DESCRIPTION
I'm experimenting with using `auditable-serde` in an existing custom build command, by updating it to run cargo_metadata and creating/injecting the compressed json manually. (Doing it this way rather than the `build.rs` way so I can roll out changes across many internal projects without having to update them all).

The build command already uses `cargo_metadata`, and I quickly ran into conflicts between the version already used and the version expected by `auditable-serde`. I've updated cargo_metadata here, and re-exported cargo_metadata to make this easier.