### PR TITLE
Update dependencies and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ The data format is designed not to disrupt reproducible builds. It contains no t
 
 It is interoperable with existing tooling that consumes Cargo.lock via the JSON-to-TOML convertor. You can also write your own tooling fairly easily - `auditable-extract` and `auditable-serde` crates handle all the data extraction and parsing for you. See [the docs](https://docs.rs/auditable-extract/) to get started.
 
+[syft](https://github.com/anchore/syft) v0.53.0+ has experimental support for detecting this data in binaries.
+When used on images or directories, Rust audit support must be enabled by adding the `--catalogers all` CLI option, e.g `syft --catalogers all <container image containing Rust auditable binary>`.
+
+[go-rustaudit](https://github.com/microsoft/go-rustaudit) is golang binary for parsing Rust audit information from binaries, used in syft.
+
 ### What is the data format, exactly?
 
 It is not yet stabilized, so we do not have extensive docs or a JSON schema. However, [these Rust data structures](https://github.com/Shnatsel/rust-audit/blob/master/auditable-serde/src/lib.rs#L14) map to JSON one-to-one and are extensively commented. The JSON is Zlib-compressed and placed in a linker section with a name that [varies by platform](https://github.com/Shnatsel/rust-audit/blob/master/auditable/src/lib.rs).

--- a/auditable-build/Cargo.toml
+++ b/auditable-build/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2018"
 
 [dependencies]
 auditable-serde = {path = "../auditable-serde", features = ["from_metadata"]}
-miniz_oxide = {version = "0.4.0"}
-serde_json = {version =  "1.0.57"}
-cargo_metadata = "0.11"
+miniz_oxide = "0.5.3"
+serde_json = "1.0.57"
+cargo_metadata = "0.15"

--- a/auditable-extract/Cargo.toml
+++ b/auditable-extract/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-binfarce = "0.1"
+binfarce = "0.2"

--- a/auditable-extract/src/lib.rs
+++ b/auditable-extract/src/lib.rs
@@ -75,6 +75,9 @@ pub enum Error {
     NotAnExecutable,
     UnexpectedEof,
     MalformedFile,
+    SymbolsSectionIsMissing,
+    SectionIsMissing,
+    UnexpectedSectionType
 }
 
 impl std::error::Error for Error {}
@@ -86,6 +89,9 @@ impl std::fmt::Display for Error {
             Error::NotAnExecutable => "Not an executable file",
             Error::UnexpectedEof => "Unexpected end of file",
             Error::MalformedFile => "Malformed executable file",
+            Error::SymbolsSectionIsMissing => "Symbols section missing from exectuable",
+            Error::SectionIsMissing => "Section is missing from executable",
+            Error::UnexpectedSectionType => "Unexpected executable section type",
         };
         write!(f, "{}", message)
     }
@@ -96,6 +102,9 @@ impl From<binfarce::ParseError> for Error {
         match e {
             binfarce::ParseError::MalformedInput => Error::MalformedFile,
             binfarce::ParseError::UnexpectedEof => Error::UnexpectedEof,
+            binfarce::ParseError::SymbolsSectionIsMissing => Error::SymbolsSectionIsMissing,
+            binfarce::ParseError::SectionIsMissing(_) => Error::SectionIsMissing,
+            binfarce::ParseError::UnexpectedSectionType { .. } => Error::UnexpectedSectionType,
         }
-    }   
+    }
 }

--- a/auditable-serde/Cargo.toml
+++ b/auditable-serde/Cargo.toml
@@ -19,9 +19,9 @@ toml = ["cargo-lock"]
 [dependencies]
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1.0.57"
-semver = { version = "0.10", features = ["serde"] }
-cargo_metadata = { version = "0.11", optional = true }
-cargo-lock = { version = "4.0.1", default-features = false, optional = true }
+semver = { version = "1.0", features = ["serde"] }
+cargo_metadata = { version = "0.15", optional = true }
+cargo-lock = { version = "8.0.2", default-features = false, optional = true }
 
 [[example]]
 name = "json-to-toml"

--- a/rust-audit-info/Cargo.toml
+++ b/rust-audit-info/Cargo.toml
@@ -12,5 +12,5 @@ edition = "2018"
 
 [dependencies]
 auditable-extract = {path = "../auditable-extract"}
-miniz_oxide = "0.4.1"
+miniz_oxide = "0.5.3"
 #pico-args = "0.3.3"


### PR DESCRIPTION
This PR upgrades dependencies to the latest versions, and adds a mention to the README about [go-rustaudit](https://github.com/microsoft/go-rustaudit), and syft which will have experimental support for Rust-audit binaries (in 0.53.0, due imminently).